### PR TITLE
Issue/85 circleci dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,18 @@ jobs:
       - run:
           name: Run linters
           command: bundle exec rake lint
+  publish:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: |
+          tmp=${CIRCLE_BRANCH##*/}
+          TAG=${tmp%%_*}
+          echo $TAG, $tmp
+          docker build -t $IMAGE:$TAG .
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+          docker push $IMAGE:$TAG
 
 workflows:
   version: 2
@@ -106,3 +118,7 @@ workflows:
       - lint:
           requires:
             - build
+      - publish:
+          requires:
+            - lint
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,8 +101,8 @@ jobs:
       - setup_remote_docker
       - run: |
           tmp=${CIRCLE_BRANCH##*/}
-          TAG=${tmp%%_*}
-          echo $TAG, $tmp
+          TAG=cci_${tmp%%_*}
+          # echo $TAG
           docker build -t $IMAGE:$TAG .
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker push $IMAGE:$TAG
@@ -121,4 +121,5 @@ workflows:
       - publish:
           requires:
             - lint
+            - test
 


### PR DESCRIPTION
Ajout d'une étape à CircleCI pour construire et publier automatiquement le container sur DockerHub seulement si les test et le lint passent. 